### PR TITLE
fix: update Few hooks imports after v4 periphery rebase

### DIFF
--- a/src/hooks/FewETHHook.sol
+++ b/src/hooks/FewETHHook.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {WETH} from "solmate/src/tokens/WETH.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {BaseTokenWrapperHook} from "../base/hooks/BaseTokenWrapperHook.sol";
+import {IFewWrappedToken} from "../interfaces/external/IFewWrappedToken.sol";
+
+/// @title Wrapped Few ETH Hook
+/// @notice Hook for wrapping/unwrapping fwWETH in Uniswap V4 pools
+/// @dev Implements 1:1 wrapping/unwrapping between ETH and fwWETH
+contract FewETHHook is BaseTokenWrapperHook {
+    /// @notice The WETH9 contract
+    WETH public immutable weth;
+    /// @notice The fwWETH contract used for wrapping/unwrapping operations
+    IFewWrappedToken public immutable fwWETH;
+
+    /// @notice Creates a new fwWETH wrapper hook
+    /// @param _manager The Uniswap V4 pool manager
+    /// @param _weth The WETH9 contract address
+    /// @param _fwWETH The fwWETH contract address
+    /// @dev Initializes with fwWETH as wrapper token and ETH as underlying token
+    constructor(IPoolManager _manager, address payable _weth, IFewWrappedToken _fwWETH)
+        BaseTokenWrapperHook(
+            _manager,
+            Currency.wrap(address(_fwWETH)), // wrapper token is fwWETH
+            CurrencyLibrary.ADDRESS_ZERO // underlying token is ETH (address(0))
+        )
+    {
+        weth = WETH(payable(_weth));
+        fwWETH = _fwWETH;
+        ERC20(weth).approve(address(fwWETH), type(uint256).max);
+    }
+
+    /// @inheritdoc BaseTokenWrapperHook
+    /// @notice Wraps ETH to fwWETH
+    /// @param underlyingAmount Amount of ETH to wrap
+    /// @return Amount of fwWETH received
+    function _deposit(uint256 underlyingAmount) internal override returns (uint256) {
+        weth.deposit{value: underlyingAmount}();
+        return fwWETH.wrap(underlyingAmount);
+    }
+
+    /// @inheritdoc BaseTokenWrapperHook
+    /// @notice Unwraps fwWETH to ETH
+    /// @param wrapperAmount Amount of fwWETH to unwrap
+    /// @return Amount of ETH received
+    function _withdraw(uint256 wrapperAmount) internal override returns (uint256) {
+        fwWETH.unwrap(wrapperAmount);
+        weth.withdraw(wrapperAmount);
+        return wrapperAmount;
+    }
+
+    /// @notice Required to receive ETH
+    receive() external payable {}
+}

--- a/src/hooks/FewETHHook.sol
+++ b/src/hooks/FewETHHook.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {WETH} from "solmate/src/tokens/WETH.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ReentrancyGuard} from "solmate/src/utils/ReentrancyGuard.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {ModifyLiquidityParams, SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";

--- a/src/hooks/FewETHHook.sol
+++ b/src/hooks/FewETHHook.sol
@@ -2,55 +2,194 @@
 pragma solidity ^0.8.0;
 
 import {WETH} from "solmate/src/tokens/WETH.sol";
-import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ReentrancyGuard} from "solmate/src/utils/ReentrancyGuard.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {ModifyLiquidityParams, SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {BaseTokenWrapperHook} from "../base/hooks/BaseTokenWrapperHook.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {BeforeSwapDelta, toBeforeSwapDelta} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
+import {BaseHook} from "../utils/BaseHook.sol";
+import {DeltaResolver} from "../base/DeltaResolver.sol";
 import {IFewWrappedToken} from "../interfaces/external/IFewWrappedToken.sol";
 
 /// @title Wrapped Few ETH Hook
 /// @notice Hook for wrapping/unwrapping fwWETH in Uniswap V4 pools
 /// @dev Implements 1:1 wrapping/unwrapping between ETH and fwWETH
-contract FewETHHook is BaseTokenWrapperHook {
+/// @dev Handles ETH to WETH conversion and WETH to fwWETH wrapping
+/// @dev Includes comprehensive input validation and security measures
+contract FewETHHook is BaseHook, DeltaResolver, ReentrancyGuard {
+    using CurrencyLibrary for Currency;
+    using SafeCast for int256;
+    using SafeCast for uint256;
+    
+    /// @notice Custom errors for better gas efficiency and clarity
+    error InvalidAddress();
+    error WrapFailed();
+    error UnwrapFailed();
+
     /// @notice The WETH9 contract
     WETH public immutable weth;
     /// @notice The fwWETH contract used for wrapping/unwrapping operations
     IFewWrappedToken public immutable fwWETH;
+
+    /// @notice The wrapped token currency (fwWETH)
+    Currency public immutable wrapperCurrency;
+    /// @notice The underlying token currency (ETH)
+    Currency public immutable underlyingCurrency;
+    /// @notice Indicates whether wrapping occurs when swapping from token0 to token1
+    bool public immutable wrapZeroForOne;
 
     /// @notice Creates a new fwWETH wrapper hook
     /// @param _manager The Uniswap V4 pool manager
     /// @param _weth The WETH9 contract address
     /// @param _fwWETH The fwWETH contract address
     /// @dev Initializes with fwWETH as wrapper token and ETH as underlying token
+    /// @dev Sets up approval for WETH to fwWETH wrapping operations
+    /// @dev Determines wrapping direction based on token address ordering
     constructor(IPoolManager _manager, address payable _weth, IFewWrappedToken _fwWETH)
-        BaseTokenWrapperHook(
-            _manager,
-            Currency.wrap(address(_fwWETH)), // wrapper token is fwWETH
-            CurrencyLibrary.ADDRESS_ZERO // underlying token is ETH (address(0))
-        )
+        BaseHook(_manager)
     {
+        // Input validation
+        if (address(_manager) == address(0)) revert InvalidAddress();
+        if (_weth == address(0)) revert InvalidAddress();
+        if (address(_fwWETH) == address(0)) revert InvalidAddress();
+        
         weth = WETH(payable(_weth));
         fwWETH = _fwWETH;
-        ERC20(weth).approve(address(fwWETH), type(uint256).max);
+        wrapperCurrency = Currency.wrap(address(_fwWETH));
+        underlyingCurrency = CurrencyLibrary.ADDRESS_ZERO;
+        wrapZeroForOne = underlyingCurrency < wrapperCurrency;
+        weth.approve(address(fwWETH), type(uint256).max);
     }
 
-    /// @inheritdoc BaseTokenWrapperHook
+    /// @notice Returns hook permissions
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: true,
+            beforeAddLiquidity: true,
+            beforeSwap: true,
+            beforeSwapReturnDelta: true,
+            afterSwap: false,
+            afterInitialize: false,
+            beforeRemoveLiquidity: false,
+            afterAddLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeDonate: false,
+            afterDonate: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    /// @notice Validates pool initialization parameters
+    /// @dev Ensures pool contains only wrapper and underlying tokens with zero fee
+    /// @param poolKey The pool configuration including tokens and fee
+    /// @return The function selector if validation passes
+    function _beforeInitialize(address, PoolKey calldata poolKey, uint160) internal view override returns (bytes4) {
+        // ensure pool tokens are the wrapper currency and underlying currency
+        bool isValidPair = wrapZeroForOne
+            ? (poolKey.currency0 == underlyingCurrency && poolKey.currency1 == wrapperCurrency)
+            : (poolKey.currency0 == wrapperCurrency && poolKey.currency1 == underlyingCurrency);
+
+        if (!isValidPair) revert("InvalidPoolToken");
+        if (poolKey.fee != 0) revert("InvalidPoolFee");
+
+        return IHooks.beforeInitialize.selector;
+    }
+
+    /// @notice Allow liquidity operations
+    function _beforeAddLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        bytes calldata
+    ) internal pure override returns (bytes4) {
+        return IHooks.beforeAddLiquidity.selector;
+    }
+
+    /// @notice Handles token wrapping and unwrapping during swaps
+    function _beforeSwap(address, PoolKey calldata, SwapParams calldata params, bytes calldata)
+        internal
+        override
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        bool isExactInput = params.amountSpecified < 0;
+
+        if (wrapZeroForOne == params.zeroForOne) {
+            // we are wrapping
+            uint256 inputAmount =
+                isExactInput ? uint256(-params.amountSpecified) : _getWrapInputRequired(uint256(params.amountSpecified));
+            _take(underlyingCurrency, address(this), inputAmount);
+            uint256 wrappedAmount = _deposit(inputAmount);
+            _settle(wrapperCurrency, address(this), wrappedAmount);
+            int128 amountUnspecified =
+                isExactInput ? -wrappedAmount.toInt256().toInt128() : inputAmount.toInt256().toInt128();
+            BeforeSwapDelta swapDelta = toBeforeSwapDelta(-params.amountSpecified.toInt128(), amountUnspecified);
+            return (IHooks.beforeSwap.selector, swapDelta, 0);
+        } else {
+            // we are unwrapping
+            uint256 inputAmount = isExactInput
+                ? uint256(-params.amountSpecified)
+                : _getUnwrapInputRequired(uint256(params.amountSpecified));
+            _take(wrapperCurrency, address(this), inputAmount);
+            uint256 unwrappedAmount = _withdraw(inputAmount);
+            _settle(underlyingCurrency, address(this), unwrappedAmount);
+            int128 amountUnspecified =
+                isExactInput ? -unwrappedAmount.toInt256().toInt128() : inputAmount.toInt256().toInt128();
+            BeforeSwapDelta swapDelta = toBeforeSwapDelta(-params.amountSpecified.toInt128(), amountUnspecified);
+            return (IHooks.beforeSwap.selector, swapDelta, 0);
+        }
+    }
+
+    /// @notice Transfers tokens to the pool manager
+    function _pay(Currency token, address, uint256 amount) internal override {
+        token.transfer(address(poolManager), amount);
+    }
+
     /// @notice Wraps ETH to fwWETH
+    /// @dev Converts ETH to WETH first, then wraps WETH to fwWETH
+    /// @dev Includes reentrancy protection and balance validation
     /// @param underlyingAmount Amount of ETH to wrap
     /// @return Amount of fwWETH received
-    function _deposit(uint256 underlyingAmount) internal override returns (uint256) {
+    function _deposit(uint256 underlyingAmount) internal nonReentrant returns (uint256) {
+        // Check if contract has sufficient ETH balance
+        if (address(this).balance < underlyingAmount) revert InsufficientBalance();
+        
         weth.deposit{value: underlyingAmount}();
-        return fwWETH.wrap(underlyingAmount);
+        uint256 wrappedAmount = fwWETH.wrap(underlyingAmount);
+        if (wrappedAmount == 0) revert WrapFailed();
+        
+        return wrappedAmount;
     }
 
-    /// @inheritdoc BaseTokenWrapperHook
     /// @notice Unwraps fwWETH to ETH
+    /// @dev Unwraps fwWETH to WETH first, then converts WETH to ETH
+    /// @dev Includes reentrancy protection and balance validation
     /// @param wrapperAmount Amount of fwWETH to unwrap
     /// @return Amount of ETH received
-    function _withdraw(uint256 wrapperAmount) internal override returns (uint256) {
+    function _withdraw(uint256 wrapperAmount) internal nonReentrant returns (uint256) {
+        // Check if contract has sufficient fwWETH balance
+        if (IERC20(address(fwWETH)).balanceOf(address(this)) < wrapperAmount) revert InsufficientBalance();
+        
         fwWETH.unwrap(wrapperAmount);
         weth.withdraw(wrapperAmount);
+        
         return wrapperAmount;
+    }
+
+    /// @notice Calculates underlying tokens needed to receive desired wrapper tokens
+    function _getWrapInputRequired(uint256 wrappedAmount) internal pure returns (uint256) {
+        return wrappedAmount;
+    }
+
+    /// @notice Calculates wrapper tokens needed to receive desired underlying tokens
+    function _getUnwrapInputRequired(uint256 underlyingAmount) internal pure returns (uint256) {
+        return underlyingAmount;
     }
 
     /// @notice Required to receive ETH

--- a/src/hooks/FewTokenHook.sol
+++ b/src/hooks/FewTokenHook.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {BaseTokenWrapperHook} from "../base/hooks/BaseTokenWrapperHook.sol";
+import {IFewWrappedToken} from "../interfaces/external/IFewWrappedToken.sol";
+
+/// @title Wrapped Few Token Hook
+/// @notice Hook for wrapping/unwrapping few token in Uniswap V4 pools
+/// @dev Implements 1:1 wrapping/unwrapping between token and few token
+contract FewTokenHook is BaseTokenWrapperHook {
+    /// @notice The fewToken contract used for wrapping/unwrapping operations
+    IFewWrappedToken public immutable fewToken;
+
+    /// @notice Creates a new fewToken wrapper hook
+    /// @param _manager The Uniswap V4 pool manager
+    /// @param _fewToken The fewToken contract address
+    /// @dev Initializes with fewToken as wrapper token and token as underlying token
+    constructor(IPoolManager _manager, IFewWrappedToken _fewToken)
+        BaseTokenWrapperHook(
+            _manager,
+            Currency.wrap(address(_fewToken)), // wrapper token is fewToken
+            Currency.wrap(_fewToken.token()) // underlying token is token
+        )
+    {
+        fewToken = _fewToken;
+        ERC20(Currency.unwrap(underlyingCurrency)).approve(address(fewToken), type(uint256).max);
+    }
+
+    /// @inheritdoc BaseTokenWrapperHook
+    /// @notice Wraps token to fewToken
+    /// @param underlyingAmount Amount of token to wrap
+    /// @return Amount of fewToken received
+    function _deposit(uint256 underlyingAmount) internal override returns (uint256) {
+        return fewToken.wrap(underlyingAmount);
+    }
+
+    /// @inheritdoc BaseTokenWrapperHook
+    /// @notice Unwraps fewToken to token
+    /// @param wrapperAmount Amount of fewToken to unwrap
+    /// @return Amount of token received
+    function _withdraw(uint256 wrapperAmount) internal override returns (uint256) {
+        return fewToken.unwrap(wrapperAmount);
+    }
+}

--- a/src/hooks/FewTokenHook.sol
+++ b/src/hooks/FewTokenHook.sol
@@ -27,8 +27,8 @@ contract FewTokenHook is BaseHook, DeltaResolver, ReentrancyGuard {
     
     /// @notice Custom errors for better gas efficiency and clarity
     error InvalidAddress();
-    error WrapFailed();
-    error UnwrapFailed();
+    error WrapFailed(uint256 expectedAmount, uint256 actualAmount);
+    error UnwrapFailed(uint256 expectedAmount, uint256 actualAmount);
 
     /// @notice The fewToken contract used for wrapping/unwrapping operations
     IFewWrappedToken public immutable fewToken;
@@ -156,7 +156,7 @@ contract FewTokenHook is BaseHook, DeltaResolver, ReentrancyGuard {
         if (balance < underlyingAmount) revert InsufficientBalance();
         
         uint256 wrappedAmount = fewToken.wrap(underlyingAmount);
-        if (wrappedAmount == 0) revert WrapFailed();
+        if (wrappedAmount != underlyingAmount) revert WrapFailed(underlyingAmount, wrappedAmount);
         
         return wrappedAmount;
     }
@@ -172,7 +172,7 @@ contract FewTokenHook is BaseHook, DeltaResolver, ReentrancyGuard {
         if (balance < wrapperAmount) revert InsufficientBalance();
         
         uint256 unwrappedAmount = fewToken.unwrap(wrapperAmount);
-        if (unwrappedAmount == 0) revert UnwrapFailed();
+        if (unwrappedAmount != wrapperAmount) revert UnwrapFailed(wrapperAmount, unwrappedAmount);
         
         return unwrappedAmount;
     }

--- a/src/hooks/FewUSDTHook.sol
+++ b/src/hooks/FewUSDTHook.sol
@@ -28,8 +28,8 @@ contract FewUSDTHook is BaseHook, DeltaResolver, ReentrancyGuard {
     using SafeCast for uint256;
     
     /// @notice Custom errors for better gas efficiency and clarity
-    error WrapFailed();
-    error UnwrapFailed();
+    error WrapFailed(uint256 expectedAmount, uint256 actualAmount);
+    error UnwrapFailed(uint256 expectedAmount, uint256 actualAmount);
     error InvalidAddress();
     
     /// @notice The fewUSDT contract used for wrapping/unwrapping operations
@@ -159,7 +159,7 @@ contract FewUSDTHook is BaseHook, DeltaResolver, ReentrancyGuard {
         if (balance < underlyingAmount) revert InsufficientBalance();
         
         uint256 wrappedAmount = fewUSDT.wrap(underlyingAmount);
-        if (wrappedAmount == 0) revert WrapFailed();
+        if (wrappedAmount != underlyingAmount) revert WrapFailed(underlyingAmount, wrappedAmount);
         
         return wrappedAmount;
     }
@@ -174,7 +174,7 @@ contract FewUSDTHook is BaseHook, DeltaResolver, ReentrancyGuard {
         if (balance < wrapperAmount) revert InsufficientBalance();
         
         uint256 unwrappedAmount = fewUSDT.unwrap(wrapperAmount);
-        if (unwrappedAmount == 0) revert UnwrapFailed();
+        if (unwrappedAmount != wrapperAmount) revert UnwrapFailed(wrapperAmount, unwrappedAmount);
         
         return unwrappedAmount;
     }

--- a/src/hooks/FewUSDTHook.sol
+++ b/src/hooks/FewUSDTHook.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "solmate/src/utils/ReentrancyGuard.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {ModifyLiquidityParams, SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
@@ -15,49 +16,52 @@ import {BaseHook} from "../utils/BaseHook.sol";
 import {DeltaResolver} from "../base/DeltaResolver.sol";
 import {IFewWrappedToken} from "../interfaces/external/IFewWrappedToken.sol";
 
-/// @title Wrapped Few Token Hook
-/// @notice Hook for wrapping/unwrapping few token in Uniswap V4 pools
-/// @dev Implements 1:1 wrapping/unwrapping between token and few token
-/// @dev Generic implementation for standard ERC20 tokens
-/// @dev Includes comprehensive input validation and security measures
-contract FewTokenHook is BaseHook, DeltaResolver, ReentrancyGuard {
+/// @title Wrapped Few USDT Token Hook
+/// @notice Hook for wrapping/unwrapping fewUSDT tokens in Uniswap V4 pools
+/// @dev Implements 1:1 wrapping/unwrapping between USDT and fewUSDT
+/// @dev Special implementation for USDT which doesn't return bool from approve function
+/// @dev Includes reentrancy protection and comprehensive input validation
+contract FewUSDTHook is BaseHook, DeltaResolver, ReentrancyGuard {
+    using SafeERC20 for IERC20;
     using CurrencyLibrary for Currency;
     using SafeCast for int256;
     using SafeCast for uint256;
     
     /// @notice Custom errors for better gas efficiency and clarity
-    error InvalidAddress();
     error WrapFailed();
     error UnwrapFailed();
+    error InvalidAddress();
+    
+    /// @notice The fewUSDT contract used for wrapping/unwrapping operations
+    IFewWrappedToken public immutable fewUSDT;
 
-    /// @notice The fewToken contract used for wrapping/unwrapping operations
-    IFewWrappedToken public immutable fewToken;
-
-    /// @notice The wrapped token currency (fewToken)
+    /// @notice The wrapped token currency (fewUSDT)
     Currency public immutable wrapperCurrency;
-    /// @notice The underlying token currency (token)
+    /// @notice The underlying token currency (USDT)
     Currency public immutable underlyingCurrency;
     /// @notice Indicates whether wrapping occurs when swapping from token0 to token1
     bool public immutable wrapZeroForOne;
 
-    /// @notice Creates a new fewToken wrapper hook
+    /// @notice Creates a new fewUSDT wrapper hook
     /// @param _manager The Uniswap V4 pool manager
-    /// @param _fewToken The fewToken contract address
-    /// @dev Initializes with fewToken as wrapper token and token as underlying token
-    /// @dev Sets up approval for token to fewToken wrapping operations
-    /// @dev Determines wrapping direction based on token address ordering
-    constructor(IPoolManager _manager, IFewWrappedToken _fewToken)
+    /// @param _fewUSDT The fewUSDT contract address
+    /// @dev Initializes with fewUSDT as wrapper token and USDT as underlying token
+    /// @dev Uses SafeERC20.forceApprove to handle USDT's non-standard approve function
+    /// @dev Includes comprehensive input validation for security
+    constructor(IPoolManager _manager, IFewWrappedToken _fewUSDT)
         BaseHook(_manager)
     {
         // Input validation
         if (address(_manager) == address(0)) revert InvalidAddress();
-        if (address(_fewToken) == address(0)) revert InvalidAddress();
+        if (address(_fewUSDT) == address(0)) revert InvalidAddress();
         
-        fewToken = _fewToken;
-        wrapperCurrency = Currency.wrap(address(_fewToken));
-        underlyingCurrency = Currency.wrap(_fewToken.token());
+        fewUSDT = _fewUSDT;
+        wrapperCurrency = Currency.wrap(address(_fewUSDT));
+        underlyingCurrency = Currency.wrap(_fewUSDT.token());
         wrapZeroForOne = underlyingCurrency < wrapperCurrency;
-        IERC20(Currency.unwrap(underlyingCurrency)).approve(address(fewToken), type(uint256).max);
+        
+        // SafeERC20.forceApprove for USDT compatibility
+        IERC20(Currency.unwrap(underlyingCurrency)).forceApprove(address(fewUSDT), type(uint256).max);
     }
 
     /// @notice Returns hook permissions
@@ -85,7 +89,7 @@ contract FewTokenHook is BaseHook, DeltaResolver, ReentrancyGuard {
     /// @param poolKey The pool configuration including tokens and fee
     /// @return The function selector if validation passes
     function _beforeInitialize(address, PoolKey calldata poolKey, uint160) internal view override returns (bytes4) {
-        // ensure pool tokens are the wrapper currency and underlying currency
+        // Ensure pool tokens are the wrapper currency and underlying currency
         bool isValidPair = wrapZeroForOne
             ? (poolKey.currency0 == underlyingCurrency && poolKey.currency1 == wrapperCurrency)
             : (poolKey.currency0 == wrapperCurrency && poolKey.currency1 == underlyingCurrency);
@@ -145,33 +149,31 @@ contract FewTokenHook is BaseHook, DeltaResolver, ReentrancyGuard {
         token.transfer(address(poolManager), amount);
     }
 
-    /// @notice Wraps token to fewToken
-    /// @dev Direct wrapping operation for standard ERC20 tokens
-    /// @dev Includes reentrancy protection and balance validation
-    /// @param underlyingAmount Amount of token to wrap
-    /// @return Amount of fewToken received
+    /// @notice Wraps USDT to fewUSDT
+    /// @dev Includes balance check and reentrancy protection
+    /// @param underlyingAmount Amount of USDT to wrap
+    /// @return Amount of fewUSDT received
     function _deposit(uint256 underlyingAmount) internal nonReentrant returns (uint256) {
-        // Check if contract has sufficient token balance
+        // Check if contract has sufficient USDT balance
         uint256 balance = IERC20(Currency.unwrap(underlyingCurrency)).balanceOf(address(this));
         if (balance < underlyingAmount) revert InsufficientBalance();
         
-        uint256 wrappedAmount = fewToken.wrap(underlyingAmount);
+        uint256 wrappedAmount = fewUSDT.wrap(underlyingAmount);
         if (wrappedAmount == 0) revert WrapFailed();
         
         return wrappedAmount;
     }
 
-    /// @notice Unwraps fewToken to token
-    /// @dev Direct unwrapping operation for standard ERC20 tokens
-    /// @dev Includes reentrancy protection and balance validation
-    /// @param wrapperAmount Amount of fewToken to unwrap
-    /// @return Amount of token received
+    /// @notice Unwraps fewUSDT to USDT
+    /// @dev Includes balance check and reentrancy protection
+    /// @param wrapperAmount Amount of fewUSDT to unwrap
+    /// @return Amount of USDT received
     function _withdraw(uint256 wrapperAmount) internal nonReentrant returns (uint256) {
-        // Check if contract has sufficient fewToken balance
+        // Check if contract has sufficient fewUSDT balance
         uint256 balance = IERC20(Currency.unwrap(wrapperCurrency)).balanceOf(address(this));
         if (balance < wrapperAmount) revert InsufficientBalance();
         
-        uint256 unwrappedAmount = fewToken.unwrap(wrapperAmount);
+        uint256 unwrappedAmount = fewUSDT.unwrap(wrapperAmount);
         if (unwrappedAmount == 0) revert UnwrapFailed();
         
         return unwrappedAmount;

--- a/src/interfaces/external/IFewWrappedToken.sol
+++ b/src/interfaces/external/IFewWrappedToken.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-interface IFewWrappedToken {
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IFewWrappedToken is IERC20 {
     function token() external view returns (address);
 
     function wrap(uint256 amount) external returns (uint256);

--- a/src/interfaces/external/IFewWrappedToken.sol
+++ b/src/interfaces/external/IFewWrappedToken.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+interface IFewWrappedToken {
+    function token() external view returns (address);
+
+    function wrap(uint256 amount) external returns (uint256);
+    function unwrap(uint256 amount) external returns (uint256);
+}


### PR DESCRIPTION
This pull request updates the Few token wrapper hooks to maintain compatibility with the latest Uniswap v4 periphery codebase after rebasing from upstream. The changes address import path modifications that occurred during the v4 periphery update.

## Key Changes

### Import Updates
- Updated `FewETHHook.sol`, `FewTokenHook.sol`, and `FewUSDTHook.sol` to import `ModifyLiquidityParams` and `SwapParams` directly from `@uniswap/v4-core/src/types/PoolOperation.sol`
- Replaced `IPoolManager.ModifyLiquidityParams` and `IPoolManager.SwapParams` references with direct type usage
- Added necessary imports for `PoolKey`, `IHooks`, `Hooks`, `BeforeSwapDelta`, and `SafeCast` libraries

### Hook Architecture Improvements
- Refactored hooks to inherit from `BaseHook` and `DeltaResolver` instead of the deprecated `BaseTokenWrapperHook`
- Implemented comprehensive hook permission system with proper `beforeInitialize`, `beforeAddLiquidity`, and `beforeSwap` handlers
- Added reentrancy protection using `ReentrancyGuard` for all wrapping/unwrapping operations
- Enhanced error handling with custom error types for better gas efficiency

### Security Enhancements
- Added input validation for all constructor parameters
- Implemented balance checks before wrapping/unwrapping operations
- Added proper error handling for failed wrap/unwrap operations
- Enhanced documentation with comprehensive NatSpec comments

### Compatibility
- Maintained 1:1 wrapping/unwrapping functionality for ETH/fwWETH, token/fewToken, and USDT/fewUSDT pairs
- Preserved existing hook behavior while updating to new v4 periphery architecture
- Ensured proper integration with Uniswap V4's delta resolution system

These updates ensure the Few token wrapper hooks remain functional and secure with the latest Uniswap v4 periphery codebase while maintaining backward compatibility with existing pool configurations.